### PR TITLE
Minor fix in the Satzung of the Fachschaft Math

### DIFF
--- a/html/Satzungen/Fachschaften/FSSatzungMathematik.html
+++ b/html/Satzungen/Fachschaften/FSSatzungMathematik.html
@@ -118,8 +118,8 @@ Mathematik-Lehramts-Studierenden der Rheinischen Friedrich-Wilhelms-Universität
 <p>(2) Beschlussfassende Organe der Fachschaft sind:</p>
 
 <ol start="1" class="Decimal">
-<li>die Fachschaftsvertretung (FSV),?</li>
-<li>der Fachschaftsrat (FSR),?</li>
+<li>die Fachschaftsvertretung (FSV),*</li>
+<li>der Fachschaftsrat (FSR),*</li>
 <li>die Fachschaftsvollversammlung (FSVV).</li>
 </ol>
 

--- a/md/Satzungen/Fachschaften/FSSatzungMathematik.md
+++ b/md/Satzungen/Fachschaften/FSSatzungMathematik.md
@@ -64,8 +64,8 @@ Mathematik-Lehramts-Studierenden der Rheinischen Friedrich-Wilhelms-Universität
 
 (2) Beschlussfassende Organe der Fachschaft sind:
 
-1. die Fachschaftsvertretung (FSV),?
-2. der Fachschaftsrat (FSR),?
+1. die Fachschaftsvertretung (FSV),*
+2. der Fachschaftsrat (FSR),*
 3. die Fachschaftsvollversammlung (FSVV).
 
 Die gewählten Organe sind mit einem Stern gekennzeichnet.


### PR DESCRIPTION
In § 2 Abs. 2 of the Satzung of the FS Math, some lines are marked with a star. These stars are referred to in § 2 Abs. 2 S. 2.

However, these stars are not displayed correctly and a "?" is shown, as the original document uses the LaTeX expression $^\star$.
I would suggest to use a simple asterisk ("*") instead.